### PR TITLE
Fix optional dependencies in tests

### DIFF
--- a/tests/test_db_connection.py
+++ b/tests/test_db_connection.py
@@ -3,7 +3,7 @@ import pytest
 from sqlalchemy import text
 from src.vysync.db import engine
 
-if "DATABASE_URL" not in os.environ:
+if engine is None:
     pytest.skip("DATABASE_URL not set", allow_module_level=True)
 
 

--- a/tests/test_db_supabase.py
+++ b/tests/test_db_supabase.py
@@ -2,10 +2,15 @@ import random
 import string
 import pytest
 from src.vysync.db import supabase, sb_upsert
-from postgrest.exceptions import APIError
+
+try:
+    from postgrest.exceptions import APIError
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    APIError = None
 
 pytestmark = pytest.mark.skipif(
-    supabase is None, reason="Supabase client not initialised (env vars missing)"
+    supabase is None or APIError is None,
+    reason="Supabase client or postgrest library not available",
 )
 
 

--- a/tests/test_supabase_api.py
+++ b/tests/test_supabase_api.py
@@ -1,24 +1,21 @@
-# test_supabase_api.py
-
 import os
-from supabase import create_client
-
-# Charge tes vars d’env
-url = os.getenv("SUPABASE_URL")
-key = os.getenv("SUPABASE_SERVICE_KEY")
-
-if not url or not key:
-    print("🛑 Variables SUPABASE_URL / SUPABASE_SERVICE_KEY manquantes")
-    exit(1)
-
-sb = create_client(url, key)
+import pytest
 
 try:
-    # Petit ping : on demande 1 ligne de sites_mapping
+    from supabase import create_client
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    create_client = None
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("SUPABASE_URL") or not os.getenv("SUPABASE_SERVICE_KEY"),
+    reason="Supabase credentials not configured",
+)
+
+@pytest.mark.skipif(create_client is None, reason="supabase package missing")
+def test_supabase_ping():
+    """Simple call to Supabase API returning at least one row."""
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SERVICE_KEY")
+    sb = create_client(url, key)
     res = sb.table("sites_mapping").select("id").limit(1).execute()
-    if res.data is not None:
-        print("✅ Supabase Data API OK – returned:", res.data)
-    else:
-        print("⚠️ Supabase Data API répondu mais pas de data")
-except Exception as e:
-    print("❌ Échec appel Data API:", e)
+    assert res.data is not None


### PR DESCRIPTION
## Summary
- allow importing `src.vysync.db` without `supabase` or DB URL
- skip DB and Supabase tests when dependencies are missing
- add a real pytest test for Supabase API

## Testing
- `python -m pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68595f5f00f8832fb57c09d0881dcd87